### PR TITLE
Fix ESLint not correctly finding JS files to lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,10 @@ import jsdoc from "eslint-plugin-jsdoc";
 
 export default defineConfig([
   {
-    files: ["source/scripts/*.{js,mjs,cjs}"],
+    files: [
+      "source/scripts/backend/*.{js,mjs,cjs}",
+      "source/scripts/frontend/*.{js,mjs,cjs}",
+    ],
     plugins: { 
       js,
       jsdoc 


### PR DESCRIPTION
# Request Contents
This request fixes an issue with ESLint that prevented it from correctly linting files. The issue was corrected by adding the context of the new `backend` and `frontend` directories in `source/scripts/` to the config file.

Closes #18.