### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.{js}]
+quote_type = double
+max_line_length = 120
+
+[*.{json,html}]
+max_line_length = off
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+quote_type = single
+max_line_length = 120


### PR DESCRIPTION
# Request Contents
This request implements the `.editorconfig` protocol to allow VSCode to properly detect indentation standards.

## Related Issues
- Closes #22.