### PR TITLE
Add initial pull request templates

### DIFF
--- a/doc/pr_templates/BUGFIX_PRTEMPLATE.md
+++ b/doc/pr_templates/BUGFIX_PRTEMPLATE.md
@@ -1,0 +1,13 @@
+# Request Contents
+This request fixes something. What is it, why have you done it, and where did you change? Include screenshots or videos if applicable.
+
+## Related Issues
+<!-- Do any issues need to know about / will be affected by this PR? Likely, the bug should have had an issue. -->
+- Closes #999
+- Interfaces with #999 because \<reasons\>
+- Partially implements #999 because \<reasons\>
+
+## Related PRs
+<!-- Are any other PRs affected by this one? -->
+- Rebase/restructure affecting #9999, closes #9999
+- Works with / Allows progress on #9999

--- a/doc/pr_templates/TASK_PRTEMPLATE.md
+++ b/doc/pr_templates/TASK_PRTEMPLATE.md
@@ -1,0 +1,13 @@
+# Request Contents
+This request modifies something. What is it, why have you done it, and where did you change? Include screenshots or videos if applicable.
+
+## Related Issues
+<!-- Do any issues need to know about / will be affected by this PR? -->
+- Closes #999
+- Interfaces with #999 because \<reasons\>
+- Partially implements #999 because \<reasons\>
+
+## Related PRs
+<!-- Are any other PRs affected by this one? -->
+- Rebase/restructure of #9999, closes #9999
+- Works with / Allows progress on #9999


### PR DESCRIPTION
# Request Contents
This request adds standardized pull request templates and requirements to improve the unification of pull request styling, reading, revision, and review.

Templates are currently located in `doc/pr_templates` as GitHub does not appear to have a way to implement UI-available PR templates.