### PR TITLE
[Fix] Round the score to prevent large floating point numbers overflowing their boxes

### DIFF
--- a/source/scripts/backend/scoringHandler.js
+++ b/source/scripts/backend/scoringHandler.js
@@ -56,6 +56,7 @@ export class scoringHandler {
 			// ->UI: Call back to UI to play joker animation (likely also score animation)
 
 			this.handler.state.handScore += cardValue;
+			this.handler.state.handScore = Math.round(this.handler.state.handScore * 10) / 10;
 			this.handler.uiInterface.updateScorekeeper({
 				handScore: this.handler.state.handScore,
 			});
@@ -113,6 +114,7 @@ export class scoringHandler {
 			this.handler.uiInterface.displayBust();
 		} else {
 			const totalAdded = this.handler.state.handScore * this.handler.state.handMult;
+			this.handler.state.handScore = Math.round(totalAdded * 10) / 10;
 			this.handler.state.roundScore += totalAdded;
 
 			// Show visual feedback for successful scoring
@@ -184,6 +186,7 @@ export class scoringHandler {
 	addChips(params, chips) {
 		// TODO: Check for jokers that may affect this
 		this.handler.state.handScore += chips;
+		this.handler.state.handScore = Math.round(this.handler.state.handScore * 10) / 10;
 		this.handler.uiInterface.updateScorekeeper({
 			handScore: this.handler.state.handScore,
 		});


### PR DESCRIPTION
# Request Contents
This request fixes an issue where multiplying chips and mult could result in an extremely large floating point number that clipped its bounding box. Small amount of changes but greatly improves UX.