### PR TITLE
[Fix] Disable manually flipping cards

### DIFF
--- a/source/scripts/frontend/CardElement.js
+++ b/source/scripts/frontend/CardElement.js
@@ -140,15 +140,7 @@ export class CardElement extends HTMLElement {
 		this._container.addEventListener("mousedown", this._onDragStart);
 		document.addEventListener("mousemove", this._onDragMove);
 		document.addEventListener("mouseup", this._onDragEnd);
-
-		this._cardFront.addEventListener("dblclick", () => {
-			if (this._wasDragged) return;
-			this.flip();
-		});
-		this._cardBack.addEventListener("dblclick", () => {
-			if (this._wasDragged) return;
-			this.flip();
-		});
+		
 		this._container.addEventListener(
 			"mouseenter",
 			this._onMouseEnterTooltip


### PR DESCRIPTION
# Request Contents

This request disables the manual flipping of cards. This was meant to be used for Boss Blinds, not for user interactions, so the event handler has been removed for double-click.